### PR TITLE
Provide module id in npm package definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.6",
     "title": "Angular Annotorious",
     "description": "Angular directive for Annotorius to start drawing and commenting to images on your Web page.",
+    "main": "js/angular-annotorious.js",
     "keywords": [
         "image",
         "annotation",


### PR DESCRIPTION
This PR is small chore to add `main` field in `package.json` to point code, allows to resolution of module path via module import. Bundlers like webpack relies on module path when picking up npm modules.
